### PR TITLE
removing the requirements of camera

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -13,7 +13,9 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <!-- Capture Activity -->
-    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-feature android:name="android.hardware.camera" android:required="false"/>
+    <uses-feature android:name="android.hardware.camera.autofocus" android:required="false"/>
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.FLASHLIGHT" />
 


### PR DESCRIPTION
wallet32 did not install on devices without a camera (Nexus 7, for example). It's not really THAT needed for the application to have a camera.

(I have made the pull request anyway :))
