### PR TITLE
Remove workaround for fast catchup

### DIFF
--- a/src/com/bonsai/wallet32/HDWallet.java
+++ b/src/com/bonsai/wallet32/HDWallet.java
@@ -90,8 +90,6 @@ public class HDWallet {
         HDSV_STDV0,	// Standard, version 0.			M/0/0'/<acct>'/<chnge>/<n>
         HDSV_STDV1	// BIP-0044.					M/44'/0'/<acct>'/<chnge>/<n>
     }
-    
-    private ECKey					mWorkaroundKey = null;
 
     private HDStructVersion			mHDStructVersion;
 
@@ -210,16 +208,6 @@ public class HDWallet {
         mAesKey = aesKey;
 
         try {
-            // See WORKAROUND below.
-            if (!walletNode.has("workaroundPrivKey")) {
-                mWorkaroundKey = new ECKey();
-                mWorkaroundKey.setCreationTimeSeconds(HDAddress.EPOCH);
-            } else {
-                byte[] privKeyBytes =
-                    Base58.decode(walletNode.getString("workaroundPrivKey"));
-                mWorkaroundKey = new ECKey(privKeyBytes, null);
-            }
-
             mWalletSeed = Base58.decode(walletNode.getString("seed"));
 
             mPassphrase = walletNode.has("passphrase") ?
@@ -329,9 +317,6 @@ public class HDWallet {
         try {
             JSONObject obj = new JSONObject();
 
-            obj.put("workaroundPrivKey",
-                    Base58.encode(mWorkaroundKey.getPrivKeyBytes()));
-
             obj.put("seed", Base58.encode(mWalletSeed));
 
             obj.put("passphrase", mPassphrase);
@@ -391,15 +376,6 @@ public class HDWallet {
         mPassphrase = passphrase;
         mBIP39Version = bip39Version;
         mHDStructVersion = hdsv;
-        
-
-        // WORKAROUND - there is a bug that watch-only addresses
-        // don't seem to properly scan historically; they use
-        // quick catchup.  Create a real key (that we ignore) as a
-        // workaround.
-        //
-        mWorkaroundKey = new ECKey();
-        mWorkaroundKey.setCreationTimeSeconds(HDAddress.EPOCH);
 
         switch (mBIP39Version) {
         case V0_5:
@@ -516,7 +492,6 @@ public class HDWallet {
     }
 
     public void gatherAllKeys(long creationTime, List<ECKey> keys) {
-        keys.add(mWorkaroundKey.encrypt(mKeyCrypter, mAesKey));
         for (HDAccount acct : mAccounts)
             acct.gatherAllKeys(mKeyCrypter, mAesKey, creationTime, keys);
     }

--- a/src/com/bonsai/wallet32/WalletService.java
+++ b/src/com/bonsai/wallet32/WalletService.java
@@ -519,7 +519,7 @@ public class WalletService extends Service
                         mLogger.info(String.format("adding %d keys",
                                                    keys.size()));
                         wallet().addKeys(keys);
-
+                        peerGroup().setFastCatchupTimeSecs(scanTime);
                         // Do we have enough margin on all our chains?
                         // Add keys to chains which don't have enough
                         // unused addresses at the end.


### PR DESCRIPTION
instead set
peerGroup().setFastCatchupTimeSecs(scanTime);
