### PR TITLE
Remove the workaround again.

### DIFF
--- a/src/com/bonsai/wallet32/HDWallet.java
+++ b/src/com/bonsai/wallet32/HDWallet.java
@@ -212,7 +212,8 @@ public class HDWallet {
         try {
             // See WORKAROUND below.
             if (!walletNode.has("workaroundPrivKey")) {
-                mWorkaroundKey = null;
+                mWorkaroundKey = new ECKey();
+                mWorkaroundKey.setCreationTimeSeconds(HDAddress.EPOCH);
             } else {
                 byte[] privKeyBytes =
                     Base58.decode(walletNode.getString("workaroundPrivKey"));
@@ -328,10 +329,8 @@ public class HDWallet {
         try {
             JSONObject obj = new JSONObject();
 
-            if (mWorkaroundKey != null) {
-                obj.put("workaroundPrivKey",
-                        Base58.encode(mWorkaroundKey.getPrivKeyBytes()));
-            }
+            obj.put("workaroundPrivKey",
+                    Base58.encode(mWorkaroundKey.getPrivKeyBytes()));
 
             obj.put("seed", Base58.encode(mWalletSeed));
 
@@ -384,8 +383,7 @@ public class HDWallet {
                     String passphrase,
                     int numAccounts,
                     MnemonicCodeX.Version bip39Version,
-                    HDStructVersion hdsv,
-                    boolean isCreate) {
+                    HDStructVersion hdsv) {
         mParams = params;
         mKeyCrypter = keyCrypter;
         mAesKey = aesKey;
@@ -400,10 +398,8 @@ public class HDWallet {
         // quick catchup.  Create a real key (that we ignore) as a
         // workaround.
         //
-        if (!isCreate) {
-            mWorkaroundKey = new ECKey();
-            mWorkaroundKey.setCreationTimeSeconds(HDAddress.EPOCH);
-        }
+        mWorkaroundKey = new ECKey();
+        mWorkaroundKey.setCreationTimeSeconds(HDAddress.EPOCH);
 
         switch (mBIP39Version) {
         case V0_5:
@@ -520,8 +516,7 @@ public class HDWallet {
     }
 
     public void gatherAllKeys(long creationTime, List<ECKey> keys) {
-        if (mWorkaroundKey != null)
-            keys.add(mWorkaroundKey.encrypt(mKeyCrypter, mAesKey));
+        keys.add(mWorkaroundKey.encrypt(mKeyCrypter, mAesKey));
         for (HDAccount acct : mAccounts)
             acct.gatherAllKeys(mKeyCrypter, mAesKey, creationTime, keys);
     }

--- a/src/com/bonsai/wallet32/HDWallet.java
+++ b/src/com/bonsai/wallet32/HDWallet.java
@@ -90,8 +90,6 @@ public class HDWallet {
         HDSV_STDV0,	// Standard, version 0.			M/0/0'/<acct>'/<chnge>/<n>
         HDSV_STDV1	// BIP-0044.					M/44'/0'/<acct>'/<chnge>/<n>
     }
-    
-    private ECKey					mWorkaroundKey = null;
 
     private HDStructVersion			mHDStructVersion;
 
@@ -210,16 +208,6 @@ public class HDWallet {
         mAesKey = aesKey;
 
         try {
-            // See WORKAROUND below.
-            if (!walletNode.has("workaroundPrivKey")) {
-                mWorkaroundKey = new ECKey();
-                mWorkaroundKey.setCreationTimeSeconds(HDAddress.EPOCH);
-            } else {
-                byte[] privKeyBytes =
-                    Base58.decode(walletNode.getString("workaroundPrivKey"));
-                mWorkaroundKey = new ECKey(privKeyBytes, null);
-            }
-
             mWalletSeed = Base58.decode(walletNode.getString("seed"));
 
             mPassphrase = walletNode.has("passphrase") ?
@@ -329,9 +317,6 @@ public class HDWallet {
         try {
             JSONObject obj = new JSONObject();
 
-            obj.put("workaroundPrivKey",
-                    Base58.encode(mWorkaroundKey.getPrivKeyBytes()));
-
             obj.put("seed", Base58.encode(mWalletSeed));
 
             obj.put("passphrase", mPassphrase);
@@ -391,15 +376,6 @@ public class HDWallet {
         mPassphrase = passphrase;
         mBIP39Version = bip39Version;
         mHDStructVersion = hdsv;
-        
-
-        // WORKAROUND - there is a bug that watch-only addresses
-        // don't seem to properly scan historically; they use
-        // quick catchup.  Create a real key (that we ignore) as a
-        // workaround.
-        //
-        mWorkaroundKey = new ECKey();
-        mWorkaroundKey.setCreationTimeSeconds(HDAddress.EPOCH);
 
         switch (mBIP39Version) {
         case V0_5:
@@ -516,7 +492,6 @@ public class HDWallet {
     }
 
     public void gatherAllKeys(long creationTime, List<ECKey> keys) {
-        keys.add(mWorkaroundKey.encrypt(mKeyCrypter, mAesKey));
         for (HDAccount acct : mAccounts)
             acct.gatherAllKeys(mKeyCrypter, mAesKey, creationTime, keys);
     }

--- a/src/com/bonsai/wallet32/RestoreWalletActivity.java
+++ b/src/com/bonsai/wallet32/RestoreWalletActivity.java
@@ -202,7 +202,6 @@ public class RestoreWalletActivity extends ActionBarActivity {
         WalletApplication wallapp = (WalletApplication) getApplicationContext();
 
         // Setup a wallet with the restore seed.
-        boolean isCreate = false;
         HDWallet hdwallet = new HDWallet(wallapp,
         							     params,
                                          wallapp.mKeyCrypter,
@@ -211,8 +210,7 @@ public class RestoreWalletActivity extends ActionBarActivity {
                                          passphrase,
                                          numaccts,
                                          bip39version,
-                                         hdsv,
-                                         isCreate);
+                                         hdsv);
         hdwallet.persist(wallapp);
 
         // Spin up the WalletService.

--- a/src/com/bonsai/wallet32/WalletService.java
+++ b/src/com/bonsai/wallet32/WalletService.java
@@ -518,7 +518,7 @@ public class WalletService extends Service
                         mLogger.info(String.format("adding %d keys",
                                                    keys.size()));
                         wallet().addKeys(keys);
-
+                        peerGroup().setFastCatchupTimeSecs(scanTime);
                         // Do we have enough margin on all our chains?
                         // Add keys to chains which don't have enough
                         // unused addresses at the end.

--- a/src/com/bonsai/wallet32/WalletService.java
+++ b/src/com/bonsai/wallet32/WalletService.java
@@ -514,7 +514,7 @@ public class WalletService extends Service
                         // WalletAppKit.
                         //
                         ArrayList<ECKey> keys = new ArrayList<ECKey>();
-                        mHDWallet.gatherAllKeys(scanTime, keys);
+                        mHDWallet.gatherAllKeys(HDAddress.EPOCH, keys);
                         mLogger.info(String.format("adding %d keys",
                                                    keys.size()));
                         wallet().addKeys(keys);

--- a/src/com/bonsai/wallet32/WalletUtil.java
+++ b/src/com/bonsai/wallet32/WalletUtil.java
@@ -135,7 +135,6 @@ public class WalletUtil {
         MnemonicCodeX.Version bip39version = MnemonicCodeX.Version.V0_6;
 
         // Setup a wallet with the seed.
-        boolean isCreate = true;
         HDWallet hdwallet = new HDWallet(wallapp,
         								 params,
                                          wallapp.mKeyCrypter,
@@ -144,8 +143,7 @@ public class WalletUtil {
                                          passphrase,
                                          numAccounts,
                                          bip39version,
-                                         HDWallet.HDStructVersion.HDSV_STDV1,
-                                         isCreate);
+                                         HDWallet.HDStructVersion.HDSV_STDV1);
         hdwallet.persist(wallapp);
     }
 


### PR DESCRIPTION
You are right, that my patch did not work, if you replay the blockchain.
... But... your new version does not work for me, too.

So, here is an approach, which works for me.
I can copy wallets via NFC and the resync shows all transactions.

Thanks! :-)
